### PR TITLE
require the server to save the transport parameter as well

### DIFF
--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -82,10 +82,10 @@ sending the close_stream (0x17f7586d2cb570) transport parameter
 understands this transport parameter MUST treat the receipt of a non-empty
 value as a connection error of type TRANSPORT_PARAMETER_ERROR.
 
-In order to allow reliable stream resets in 0-RTT packets, the client MUST
-remember the value of this transport parameter.  If 0-RTT data is accepted by
-the server, the server MUST not disable this extension on the resumed
-connection.
+In order to allow reliable stream resets in 0-RTT packets, both client and
+server MUST remember the value of this transport parameter.  If 0-RTT data is
+accepted by the server, the server MUST not disable this extension on the
+resumed connection.
 
 # CLOSE_STREAM Frame
 

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -82,9 +82,9 @@ sending the close_stream (0x17f7586d2cb570) transport parameter
 understands this transport parameter MUST treat the receipt of a non-empty
 value as a connection error of type TRANSPORT_PARAMETER_ERROR.
 
-In order to allow reliable stream resets in 0-RTT packets, both client and
-server MUST remember the value of this transport parameter.  If 0-RTT data is
-accepted by the server, the server MUST not disable this extension on the
+In order to allow reliable stream resets in 0-RTT packets, both endpoints MUST
+remember the value of this transport parameter.  If 0-RTT data is
+accepted by the server, the server MUST NOT disable this extension on the
 resumed connection.
 
 # CLOSE_STREAM Frame


### PR DESCRIPTION
The server needs to remember the transport parameter as well, otherwise it won't be able to tell if the extension is in use when resuming a 0-RTT connection. It also wouldn't be able to reject 0-RTT if it doesn't enable the extension any more.