### PR TITLE
don't cite RFCs in the abstract

### DIFF
--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -33,7 +33,7 @@ informative:
 
 --- abstract
 
-QUIC ({{!RFC9000}}) defines a RESET_STREAM frame to reset a stream. When a
+QUIC (RFC9000) defines a RESET_STREAM frame to reset a stream. When a
 sender resets a stream, it stops retransmitting STREAM frames for this stream.
 On the receiver side, there is no guarantee that any of the data sent on that
 stream is delivered to the application.


### PR DESCRIPTION
As @martinthomson pointed out on one of my other drafts, the abstract shouldn't contain any citations.