### PR TITLE
choosing RESET_STREAM or RESET_STREAM_AT

### DIFF
--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -135,7 +135,7 @@ to transmission and acknowledgement of other frames (see {{multiple-frames}}).
 
 # Resetting Streams
 
-When resetting a stream while requesting some bytes to delivered to the peer
+When resetting a stream requesting some bytes to delivered to the peer
 application, an endpoint sends a RESET_STREAM_AT frame with the Reliable Size field
 specifying the amount of data to be delivered to the peer.
 

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -140,8 +140,9 @@ the sender sends a RESET_STREAM_AT frame with the Reliable Size field specifying
 the amount of data to be delivered.
 
 When resetting a stream without the intent to deliver any data to the receiver,
-the sender MAY use a RESET_STREAM_AT frame with a Reliable Size of zero instead of
-using a RESET_STREAM frame. These two are identical and the behavior of
+the sender uses a RESET_STREAM frame (Section 3.2 of {{!RFC9000}}). The sender
+MAY also use a RESET_STREAM_AT frame with a Reliable Size of zero in place of a
+a RESET_STREAM frame. These two are identical and the behavior of
 RESET_STREAM frame is unchanged from the behavior described in {{!RFC9000}}.
 
 When using a RESET_STREAM_AT frame, the initiator MUST guarantee reliable delivery

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -140,7 +140,7 @@ the sender sends a RESET_STREAM_AT frame with the Reliable Size field specifying
 the amount of data to be delivered.
 
 When resetting a stream without the intent to deliver any data to the receiver,
-the sender uses a RESET_STREAM frame (Section 3.2 of {{!RFC9000}}). The sender
+the sender uses a RESET_STREAM frame ({{Section 3.2 of RFC9000}}). The sender
 MAY also use a RESET_STREAM_AT frame with a Reliable Size of zero in place of a
 a RESET_STREAM frame. These two are identical and the behavior of
 RESET_STREAM frame is unchanged from the behavior described in {{!RFC9000}}.

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -135,9 +135,15 @@ to transmission and acknowledgement of other frames (see {{multiple-frames}}).
 
 # Resetting Streams
 
-When resetting a stream, the node has the choice between using a RESET_STREAM
-frame and a RESET_STREAM_AT frame. When using a RESET_STREAM frame, the behavior is
-unchanged from the behavior described in ({{!RFC9000}}).
+When resetting a stream while requesting some bytes to delivered to the peer
+application, an endpoint sends a RESET_STREAM_AT frame with the Reliable Size field
+specifying the amount of data to be delivered to the peer.
+
+When resetting a stream without requesting any data to be delivered to the peer
+application, an endpoint MAY use a RESET_STREAM_AT frame with a Reliable Size of
+zero instead of using a RESET_STREAM frame. These two are identical and the
+behavior of RESET_STREAM frame is unchanged from the behavior described in
+{{!RFC9000}}.
 
 When using a RESET_STREAM_AT frame, the initiator MUST guarantee reliable delivery
 of stream data of at least Reliable Size bytes. If STREAM frames containing data

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -135,15 +135,14 @@ to transmission and acknowledgement of other frames (see {{multiple-frames}}).
 
 # Resetting Streams
 
-When resetting a stream requesting some bytes to be delivered to the peer
-application, an endpoint sends a RESET_STREAM_AT frame with the Reliable Size field
-specifying the amount of data to be delivered to the peer.
+When a sender wants to reset a stream but also deliver some bytes to the receiver,
+the sender sends a RESET_STREAM_AT frame with the Reliable Size field specifying
+the amount of data to be delivered.
 
-When resetting a stream without requesting any data to be delivered to the peer
-application, an endpoint MAY use a RESET_STREAM_AT frame with a Reliable Size of
-zero instead of using a RESET_STREAM frame. These two are identical and the
-behavior of RESET_STREAM frame is unchanged from the behavior described in
-{{!RFC9000}}.
+When resetting a stream without the intent to deliver any data to the receiver,
+the sender MAY use a RESET_STREAM_AT frame with a Reliable Size of zero instead of
+using a RESET_STREAM frame. These two are identical and the behavior of
+RESET_STREAM frame is unchanged from the behavior described in {{!RFC9000}}.
 
 When using a RESET_STREAM_AT frame, the initiator MUST guarantee reliable delivery
 of stream data of at least Reliable Size bytes. If STREAM frames containing data

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -135,7 +135,7 @@ to transmission and acknowledgement of other frames (see {{multiple-frames}}).
 
 # Resetting Streams
 
-When resetting a stream requesting some bytes to delivered to the peer
+When resetting a stream requesting some bytes to be delivered to the peer
 application, an endpoint sends a RESET_STREAM_AT frame with the Reliable Size field
 specifying the amount of data to be delivered to the peer.
 


### PR DESCRIPTION
Be clear that RESET_STREAM is equivalent to RESET_STREAM_AT with Reliable Size of 0, and that the sender can use either of the two.

Closes #20.