### PR TITLE
clarify that neither Reliable Size nor error code is a reliable signal

### DIFF
--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -146,7 +146,7 @@ up to that byte offset are lost, the initiator MUST retransmit this data, as
 described in ({{Section 13.3 of RFC9000}}). Data sent beyond that byte offset
 SHOULD NOT be retransmitted.
 
-As described in {{Section 3 of RFC 9000}}, stream reset signals are not guaranteed
+As described in {{Section 3 of RFC9000}}, stream reset signals are not guaranteed
 to traverse to the receiver. QUIC stacks might deliver data beyond the specified
 offset to the receiving application.
 

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -146,9 +146,11 @@ up to that byte offset are lost, the initiator MUST retransmit this data, as
 described in ({{Section 13.3 of RFC9000}}). Data sent beyond that byte offset
 SHOULD NOT be retransmitted.
 
-As described in {{Section 3 of RFC9000}}, stream reset signals are not guaranteed
-to traverse to the receiver. QUIC stacks might deliver data beyond the specified
-offset to the receiving application.
+As described in {{Section 3.2 of RFC9000}}, a stream reset signal might be
+suppressed or withheld, and the same applies to a stream reset signal carried in
+a RESET_STREAM_AT frame. Similary, the Reliable Size of the RESET_STREAM_AT
+frame doesn't prevent the QUIC stacks from delivering more data beyond the
+specified offset to the receiving application.
 
 ## Multiple RESET_STREAM_AT / RESET_STREAM frames {#multiple-frames}
 

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -146,11 +146,11 @@ up to that byte offset are lost, the initiator MUST retransmit this data, as
 described in ({{Section 13.3 of RFC9000}}). Data sent beyond that byte offset
 SHOULD NOT be retransmitted.
 
-As described in {{Section 3.2 of RFC9000}}, a receiver MAY deliver data beyond that
-offset to the application. An sender MAY choose a Reliable Size that is greater
-than the offset supplied by the application. There is no guarantee that the error
-code or the offset that were set by the sending application traverses to the
-receiving application.
+As described in {{Section 3.2 of RFC9000}}, QUIC stacks MAY deliver data beyond
+that offset to the receiving application. An sending QUIC stack MAY choose a
+Reliable Size that is greater than the offset supplied by the sending application.
+There is no guarantee that the error code or the offset that were set by the
+sending application traverses to the receiving application.
 
 ## Multiple RESET_STREAM_AT / RESET_STREAM frames {#multiple-frames}
 

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -148,9 +148,9 @@ SHOULD NOT be retransmitted.
 
 As described in {{Section 3.2 of RFC9000}}, QUIC stacks MAY deliver data beyond
 that offset to the receiving application. An sending QUIC stack MAY choose a
-Reliable Size that is greater than the offset supplied by the sending application.
-There is no guarantee that the error code or the offset that were set by the
-sending application traverses to the receiving application.
+Reliable Size that is greater than the offset supplied by the application.
+Applications MUST NOT assume that the error code or the offset traverses to their
+peers.
 
 ## Multiple RESET_STREAM_AT / RESET_STREAM frames {#multiple-frames}
 

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -146,8 +146,11 @@ up to that byte offset are lost, the initiator MUST retransmit this data, as
 described in ({{Section 13.3 of RFC9000}}). Data sent beyond that byte offset
 SHOULD NOT be retransmitted.
 
-As described in {{Section 3.2 of RFC9000}}, it MAY deliver data beyond that
-offset to the application.
+As described in {{Section 3.2 of RFC9000}}, a receiver MAY deliver data beyond that
+offset to the application. An sender MAY choose a Reliable Size that is greater
+than the offset supplied by the application. There is no guarantee that the error
+code or the offset that were set by the sending application traverses to the
+receiving application.
 
 ## Multiple RESET_STREAM_AT / RESET_STREAM frames {#multiple-frames}
 

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -149,7 +149,7 @@ SHOULD NOT be retransmitted.
 As described in {{Section 3.2 of RFC9000}}, a stream reset signal might be
 suppressed or withheld, and the same applies to a stream reset signal carried in
 a RESET_STREAM_AT frame. Similary, the Reliable Size of the RESET_STREAM_AT
-frame doesn't prevent the QUIC stacks from delivering more data beyond the
+frame does not prevent the QUIC stacks from delivering data beyond the
 specified offset to the receiving application.
 
 ## Multiple RESET_STREAM_AT / RESET_STREAM frames {#multiple-frames}

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -149,7 +149,7 @@ SHOULD NOT be retransmitted.
 As described in {{Section 3.2 of RFC9000}}, a stream reset signal might be
 suppressed or withheld, and the same applies to a stream reset signal carried in
 a RESET_STREAM_AT frame. Similary, the Reliable Size of the RESET_STREAM_AT
-frame does not prevent the QUIC stacks from delivering data beyond the
+frame does not prevent a QUIC stack from delivering data beyond the
 specified offset to the receiving application.
 
 ## Multiple RESET_STREAM_AT / RESET_STREAM frames {#multiple-frames}

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -146,11 +146,9 @@ up to that byte offset are lost, the initiator MUST retransmit this data, as
 described in ({{Section 13.3 of RFC9000}}). Data sent beyond that byte offset
 SHOULD NOT be retransmitted.
 
-As described in {{Section 3.2 of RFC9000}}, QUIC stacks MAY deliver data beyond
-that offset to the receiving application. An sending QUIC stack MAY choose a
-Reliable Size that is greater than the offset supplied by the application.
-Applications MUST NOT assume that the error code or the offset traverses to their
-peers.
+As described in {{Section 3 of RFC 9000}}, stream reset signals are not guaranteed
+to traverse to the receiver. QUIC stacks might deliver data beyond the specified
+offset to the receiving application.
 
 ## Multiple RESET_STREAM_AT / RESET_STREAM frames {#multiple-frames}
 


### PR DESCRIPTION
Closes #33.