### PR TITLE
describe state transition when sending multiple RESET_STREAM_AT frames

### DIFF
--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -164,7 +164,7 @@ The initiator MAY send multiple RESET_STREAM_AT frames for the same
 stream in order to reduce the Reliable Size.  It MAY also send a RESET_STREAM
 frame, which is equivalent to sending a RESET_STREAM_AT frame with a
 Reliable Size of 0. When reducing the Reliable Size, the sender MUST retransmit
-the RELIABLE_RESET_AT frame carrying the smallest Reliable Size as well as
+the RESET_STREAM_AT frame carrying the smallest Reliable Size as well as
 stream data up to that size, until acknowledgements are received.
 
 When sending multiple frames for the same stream, the initiator MUST NOT increase

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -165,7 +165,8 @@ stream in order to reduce the Reliable Size.  It MAY also send a RESET_STREAM
 frame, which is equivalent to sending a RESET_STREAM_AT frame with a
 Reliable Size of 0. When reducing the Reliable Size, the sender MUST retransmit
 the RESET_STREAM_AT frame carrying the smallest Reliable Size as well as
-stream data up to that size, until acknowledgements are received.
+stream data up to that size, until all acknowledgements for stream data and the
+RESET_STREAM_AT frame are received.
 
 When sending multiple frames for the same stream, the initiator MUST NOT increase
 the Reliable Size.  When receiving a RESET_STREAM_AT frame with a lower

--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -163,7 +163,9 @@ specified offset to the receiving application.
 The initiator MAY send multiple RESET_STREAM_AT frames for the same
 stream in order to reduce the Reliable Size.  It MAY also send a RESET_STREAM
 frame, which is equivalent to sending a RESET_STREAM_AT frame with a
-Reliable Size of 0.
+Reliable Size of 0. When reducing the Reliable Size, the sender MUST retransmit
+the RELIABLE_RESET_AT frame carrying the smallest Reliable Size as well as
+stream data up to that size, until acknowledgements are received.
 
 When sending multiple frames for the same stream, the initiator MUST NOT increase
 the Reliable Size.  When receiving a RESET_STREAM_AT frame with a lower


### PR DESCRIPTION
... by clarifying what do do when reducing Reliable Size in terms of information to retransmit.

Closes #23. Alternative to #35.