### PR TITLE
fix mis-rendering of a list

### DIFF
--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -193,6 +193,7 @@ might prevent the sender from sending all bytes up to the Reliable Size at once.
 
 To the endpoints, the only differences from closing a stream by using the FIN
 bit are:
+
 - the offset up to which the sender commits to sending might be smaller than
   Final Size,
 - this offset might get reduced by subsequent RESET_STREAM_AT frames,


### PR DESCRIPTION
At the moment, the list is not rendered as a list. Adding an empty line right above will fix that, hopefully.