### PR TITLE
clarify that the extension needs to be remembered for 0-RTT

### DIFF
--- a/draft-ietf-quic-reliable-stream-reset.md
+++ b/draft-ietf-quic-reliable-stream-reset.md
@@ -89,8 +89,8 @@ sending the RESET_STREAM_AT (0x17f7586d2cb570) transport parameter
 understands this transport parameter MUST treat the receipt of a non-empty
 value as a connection error of type TRANSPORT_PARAMETER_ERROR.
 
-In order to allow reliable stream resets in 0-RTT packets, both endpoints MUST
-remember the value of this transport parameter.  If 0-RTT data is
+When using 0-RTT, both endpoints MUST remember the value of this transport
+parameter. This allows use of this extension in 0-RTT packets. If 0-RTT data is
 accepted by the server, the server MUST NOT disable this extension on the
 resumed connection.
 


### PR DESCRIPTION
The "In order to allow reliable stream resets in 0-RTT packets" is not as clear as it could be. It might be interpreted that it's ok to not remember the extension for the client if it doesn't intend to use RESET_STREAM_AT frames in 0-RTT frames.